### PR TITLE
Tests and http timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Error handler that posts crash reports to Rollbar.com.
 -type opts() :: [opt()]|[].
 -spec start(access_token()) -> ok.
 -spec start(access_token(), opts()) -> ok.
+-spec stop() -> ok.
 ```
 
 ## Running the tests

--- a/src/erollbar.erl
+++ b/src/erollbar.erl
@@ -16,13 +16,15 @@
                {sha, binary()}.
 -type opts() :: [opt()]|[].
 -define(ENDPOINT, <<"https://api.rollbar.com/api/1">>).
+-define(HANDLER_NAME, erollbar_handler).
 -export_type([access_token/0
               ,opt/0
               ,opts/0
               ,info_fun/0
               ,ms/0]).
 -export([start/1
-         ,start/2]).
+         ,start/2,
+         stop/0]).
 
 -spec start(access_token()) -> ok.
 start(AccessToken) ->
@@ -38,7 +40,11 @@ start(AccessToken, Opts) ->
                           ,{host, hostname()}
                          ], Opts),
     Opts2 = validate_opts(Opts1, []),
-    ok = error_logger:add_report_handler(erollbar_handler, [AccessToken, Opts2]).
+    ok = error_logger:add_report_handler(?HANDLER_NAME, [AccessToken, Opts2]).
+
+-spec stop() -> ok | term() | {'EXIT', term()}.
+stop() ->
+    error_logger:delete_report_handler(?HANDLER_NAME).
 
 %% Internal
 set_defaults([], Opts) ->
@@ -93,6 +99,7 @@ info(Details) ->
                                   {FmtStr ++ " ~p=~p", FmtLst ++ [K, V]}
                           end,
                           {undefined, []}, Details),
+    ct:pal("called info"),
     error_logger:info_msg(FmtStr, FmtList).
 
 hostname() ->

--- a/src/erollbar.erl
+++ b/src/erollbar.erl
@@ -34,7 +34,7 @@ start(AccessToken, Opts) ->
                           ,{platform, <<"beam">>}
                           ,{batch_max, 10}
                           ,{endpoint, ?ENDPOINT}
-                          ,{info_fun, fun info/2}
+                          ,{info_fun, fun info/1}
                           ,{host, hostname()}
                          ], Opts),
     Opts2 = validate_opts(Opts1, []),
@@ -85,7 +85,7 @@ get_application_modules([App|Rest], Retval) ->
     {ok, Modules} = application:get_key(App, modules),
     get_application_modules(Rest, Retval ++ Modules).
 
-info(undefined, Details) ->
+info(Details) ->
     {FmtStr, FmtList} = lists:foldl(
                           fun({K, V}, {undefined, FmtLst}) ->
                                   {"~p=~p", FmtLst ++ [K, V]};

--- a/test/erollbar_basic_SUITE.erl
+++ b/test/erollbar_basic_SUITE.erl
@@ -3,15 +3,19 @@
 
 -export([all/0]).
 -export([init_per_suite/1
-	 ,end_per_suite/1]).
+	 ,end_per_suite/1
+         ,init_per_testcase/2
+         ,end_per_testcase/2]).
 
 -export([default_settings/1
+         ,max_time/1
         ]).
 
 -export([server/2]).
 
 all() ->
     [default_settings
+     ,max_time
     ].
 
 init_per_suite(Config) ->
@@ -23,6 +27,13 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     Config.
 
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(_, Config) ->
+    ok = erollbar:stop(),
+    Config.
+    
 %% Tests
 default_settings(Config) ->
     % Get a crash report
@@ -36,31 +47,55 @@ default_settings(Config) ->
     erollbar:start(AccessCode, [{endpoint, list_to_binary("http://127.0.0.1:"++integer_to_list(Port))},
                                 {batch_max, 0}]),
     proc_lib:spawn(fun() -> 1/0 end),
-    receive
-        Data ->
-            Body = parse_http(Data),
-            BodyParsed = jsx:decode(Body),
-            AccessCode = proplists:get_value(<<"access_token">>, BodyParsed),
-            DataPart = proplists:get_value(<<"data">>, BodyParsed),
-            <<"prod">> = proplists:get_value(<<"environment">>, DataPart),
-            BodyPart = proplists:get_value(<<"body">>, DataPart),
-            <<"error">> = proplists:get_value(<<"level">>, BodyPart),
-            <<"beam">> = proplists:get_value(<<"platform">>, BodyPart),
-            <<"erlang">> = proplists:get_value(<<"language">>, BodyPart),
-            Trace = proplists:get_value(<<"trace">>, BodyPart),
-            [Frame1, _] = proplists:get_value(<<"frames">>, Trace),
-            <<"-default_settings/1-fun-1-/0">> = proplists:get_value(<<"method">>, Frame1),
-            Filename = proplists:get_value(<<"filename">>, Frame1),
-            {_, _} = binary:match(Filename, <<"erollbar_basic_SUITE.erl">>),
-            ServerPart = proplists:get_value(<<"server">>, BodyParsed),
-            {ok, Hostname} = inet:gethostname(),
-            Hostname = binary_to_list(proplists:get_value(<<"host">>, ServerPart))
-    after 1000 ->
-            throw(test_timeout)
-    end,
+    [Data] = get_msg(1),
+    Body = parse_http(Data),
+    BodyParsed = jsx:decode(Body),
+    AccessCode = proplists:get_value(<<"access_token">>, BodyParsed),
+    DataPart = proplists:get_value(<<"data">>, BodyParsed),
+    <<"prod">> = proplists:get_value(<<"environment">>, DataPart),
+    BodyPart = proplists:get_value(<<"body">>, DataPart),
+    <<"error">> = proplists:get_value(<<"level">>, BodyPart),
+    <<"beam">> = proplists:get_value(<<"platform">>, BodyPart),
+    <<"erlang">> = proplists:get_value(<<"language">>, BodyPart),
+    Trace = proplists:get_value(<<"trace">>, BodyPart),
+    [Frame1, _] = proplists:get_value(<<"frames">>, Trace),
+    <<"-default_settings/1-fun-1-/0">> = proplists:get_value(<<"method">>, Frame1),
+    Filename = proplists:get_value(<<"filename">>, Frame1),
+    {_, _} = binary:match(Filename, <<"erollbar_basic_SUITE.erl">>),
+    ServerPart = proplists:get_value(<<"server">>, BodyParsed),
+    {ok, Hostname} = inet:gethostname(),
+    Hostname = binary_to_list(proplists:get_value(<<"host">>, ServerPart)),
+    Config.
+
+max_time(Config) ->
+    Self = self(),
+    Port = create([{ondata, fun(ASocket, Data, _) ->
+                                    Self ! Data,
+                                    gen_tcp:send(ASocket, "HTTP/1.1 200 OK\r\n\r\n"),
+                                    die
+                            end}]),
+    AccessCode = <<"test_code">>,
+    erollbar:start(AccessCode, [{endpoint, list_to_binary("http://localhost:"++integer_to_list(Port))},
+                                {batch_max, 15}, {time_max, 10}]),
+    proc_lib:spawn(fun() -> 1/0 end),
+    timer:sleep(10),
+    [_] = get_msg(1),
     Config.
 
 % Internal
+get_msg(Count) ->
+    get_msg(Count, []).
+
+get_msg(0, Retval) ->
+    Retval;
+get_msg(N, Retval) ->
+    receive
+        Data ->
+            get_msg(N-1, Retval++[Data])
+    after 6000 ->
+            throw(test_timeout)
+    end.
+
 parse_http(Data) ->
     {ok, Request, Remainder} = erlang:decode_packet(http, Data, []),
     consume_headers([Request], Remainder).
@@ -92,6 +127,7 @@ server(LSocket, Opts) ->
     loop(ASocket, Opts, State),
     case proplists:get_value(restart, Opts, false) of
         true ->
+            ct:pal("RESTARTING"),
             server(LSocket, Opts);
         false ->
             ok


### PR DESCRIPTION
- Added another test that tests the time_max config variable;
- Found a silly error in default logger and fixed it, logging is not safe again;
- Made sure that the HTTP call to rollbar.com will timeout. Value is hardcoded to 5000ms.
