### PR TITLE
Send exception in data.body.trace.exception

### DIFF
--- a/src/erollbar_encoder.erl
+++ b/src/erollbar_encoder.erl
@@ -52,8 +52,7 @@ encode_trace(Trace, #details{send_args=SendArgs}) ->
     Exception = encode_content([{<<"class">>, Class},
                                 {<<"message">>, Message},
                                 {<<"description">>, Description}]),
-    [{<<"trace">>, [{<<"frames">>, Frames1}]},
-     {<<"exception">>, Exception}].
+    [{<<"trace">>, [{<<"frames">>, Frames1}, {<<"exception">>, Exception}]}].
 
 encode_message(Message, _Details) ->
     {_, Body} = lists:keyfind(body, 1, Message),


### PR DESCRIPTION
Hi! I found that this small change keeps compatibility with the current Rollbar API, and I'm using it in production just fine.

Figured I might as well PR it back 😄 